### PR TITLE
Blank out the Google Analytics tracking id from midwest.io.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -23,7 +23,7 @@
             $(function(){$.scrollIt({scrollTime: 1000, topOffset: -82});});
         </script><script type=text/javascript>
           var _gaq = _gaq || [];
-          _gaq.push(['_setAccount', 'UA-48239617-1']);
+          _gaq.push(['_setAccount', 'UA-XXXX']);
           _gaq.push(['_trackPageview']);
 
           (function() {

--- a/index.html
+++ b/index.html
@@ -735,7 +735,7 @@
 
         <script type="text/javascript">
           var _gaq = _gaq || [];
-          _gaq.push(['_setAccount', 'UA-48239617-1']);
+          _gaq.push(['_setAccount', 'UA-XXXX']);
           _gaq.push(['_trackPageview']);
 
           (function() {


### PR DESCRIPTION
This tracking id was originally copied from the Midwest.io website code:
https://github.com/midwestio/midwestio.github.io/blob/2014/index.html#L685

This is causing me to see your website traffic on my Google Analytics reports. :open_mouth: 

Feel free to change this your own Google Analytics id -- or just remove it completely if you don't need this.